### PR TITLE
Fix documents option configuration

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
@@ -8,7 +8,7 @@
     <Product />
     <Description>Swagger and Swagger UI in Azure Functions by Swashbuckle</Description>
     <AssemblyName>AzureFunctions.Extensions.Swashbuckle</AssemblyName>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <RootNamespace>AzureFunctions.Extensions.Swashbuckle</RootNamespace>
     <Copyright>yuka1984</Copyright>
     <PackageProjectUrl>https://github.com/yuka1984/azure-functions-extensions-swashbuckle</PackageProjectUrl>

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Option.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Option.cs
@@ -7,10 +7,7 @@
         public string XmlPath { get; set; }
         public bool AddCodeParamater { get; set; } = true;
 
-        public OptionDocument[] Documents { get; set; } = new OptionDocument[]
-        {
-            new OptionDocument(), 
-        };
+        public OptionDocument[] Documents { get; set; } = {};
     }
 
     public class OptionDocument

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle
 {
@@ -106,14 +107,17 @@ namespace AzureFunctions.Extensions.Swashbuckle
             services.AddSingleton<IApiDescriptionGroupCollectionProvider>(_apiDescriptionGroupCollectionProvider);
             services.AddSwaggerGen(options =>
             {
-                foreach (var optionDocument in _option.Documents)
+                if (_option.Documents.Length == 0)
                 {
-                    options.SwaggerDoc(optionDocument.Name, new Info
+                    var defaultDocument = new OptionDocument();
+                    AddSwaggerDocument(options, defaultDocument);
+                }
+                else
+                {
+                    foreach (var optionDocument in _option.Documents)
                     {
-                        Title = optionDocument.Title,
-                        Version = optionDocument.Version,
-                        Description = optionDocument.Description
-                    });
+                        AddSwaggerDocument(options, optionDocument);
+                    }
                 }
                 
                 options.DescribeAllEnumsAsStrings();
@@ -148,6 +152,16 @@ namespace AzureFunctions.Extensions.Swashbuckle
         public Task<HttpResponseMessage> ConvertAsync(HttpRequestMessage input, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
+        }
+
+        private static void AddSwaggerDocument(SwaggerGenOptions options, OptionDocument document)
+        {
+            options.SwaggerDoc(document.Name, new Info
+            {
+                Title = document.Title,
+                Version = document.Version,
+                Description = document.Description,
+            });
         }
     }
 }


### PR DESCRIPTION
When adding a document for "v1", the following exception throws in console:

> System.Private.CoreLib: Exception while executing function: Swagger. System.Private.CoreLib: An item with the same key has already been added. Key: v1.

host.json:
```json
{
    "version": "2.0",
    "extensions": {
        "Swashbuckle": {
            "Title": "Swagger Title",
            "XmlPath": "FunctionDocs.xml",
            "Documents": [
                {
                    "Name": "v1",
                    "Title": "Swagger v1 Title",
                    "Version": "v1",
                    "Description": "Swagger v1 Description"
                }
            ]
        }
    }
}
```