### PR TITLE
Show host url in json document

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/ISwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/ISwashBuckleClient.cs
@@ -4,7 +4,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
 {
     public interface ISwashBuckleClient
     {
-        Stream GetSwaggerDocument(string documentName = "v1", string host = null);
+        Stream GetSwaggerDocument(string host, string documentName = "v1");
 
         Stream GetSwaggerUi(string swaggerUrl);
 

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/ISwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/ISwashBuckleClient.cs
@@ -4,7 +4,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
 {
     public interface ISwashBuckleClient
     {
-        Stream GetSwaggerDocument(string documentName = "v1");
+        Stream GetSwaggerDocument(string documentName = "v1", string host = null);
 
         Stream GetSwaggerUi(string swaggerUrl);
 

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClient.cs
@@ -13,7 +13,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
 
         public Stream GetSwaggerDocument(string host, string documentName = "v1")
         {
-            return _config.GetSwaggerDocument(documentName, host);
+            return _config.GetSwaggerDocument(host, documentName);
         }
 
         public Stream GetSwaggerUi(string swaggerUrl)

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClient.cs
@@ -11,9 +11,9 @@ namespace AzureFunctions.Extensions.Swashbuckle
             _config = config;
         }
 
-        public Stream GetSwaggerDocument(string documentName = "v1")
+        public Stream GetSwaggerDocument(string documentName = "v1", string host = null)
         {
-            return _config.GetSwaggerDocument(documentName);
+            return _config.GetSwaggerDocument(documentName, host);
         }
 
         public Stream GetSwaggerUi(string swaggerUrl)

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClient.cs
@@ -11,7 +11,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
             _config = config;
         }
 
-        public Stream GetSwaggerDocument(string documentName = "v1", string host = null)
+        public Stream GetSwaggerDocument(string host, string documentName = "v1")
         {
             return _config.GetSwaggerDocument(documentName, host);
         }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClientExtension.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClientExtension.cs
@@ -10,7 +10,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
         public static HttpResponseMessage CreateSwaggerDocumentResponse(this ISwashBuckleClient client,
             HttpRequestMessage requestMessage, string documentName = "v1")
         {
-            var stream = client.GetSwaggerDocument(documentName);
+            var stream = client.GetSwaggerDocument(documentName, requestMessage.RequestUri.Host);
             var reader = new StreamReader(stream);
             var document = reader.ReadToEnd();
 

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClientExtension.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClientExtension.cs
@@ -10,7 +10,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
         public static HttpResponseMessage CreateSwaggerDocumentResponse(this ISwashBuckleClient client,
             HttpRequestMessage requestMessage, string documentName = "v1")
         {
-            var stream = client.GetSwaggerDocument(documentName, requestMessage.RequestUri.Host);
+            var stream = client.GetSwaggerDocument(requestMessage.RequestUri.Host, documentName);
             var reader = new StreamReader(stream);
             var document = reader.ReadToEnd();
 

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
@@ -134,10 +134,10 @@ namespace AzureFunctions.Extensions.Swashbuckle
 
         }
 
-        public Stream GetSwaggerDocument(string documentName = "v1")
+        public Stream GetSwaggerDocument(string documentName = "v1", string host = null)
         {
             var requiredService = _serviceProvider.GetRequiredService<ISwaggerProvider>();
-            var swaggerDocument = requiredService.GetSwagger(documentName);
+            var swaggerDocument = requiredService.GetSwagger(documentName, host);
             var mem = new MemoryStream();
             var streamWriter = new StreamWriter(mem);
             var mvcOptionsAccessor =

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
@@ -134,7 +134,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
 
         }
 
-        public Stream GetSwaggerDocument(string documentName = "v1", string host = null)
+        public Stream GetSwaggerDocument(string host, string documentName = "v1")
         {
             var requiredService = _serviceProvider.GetRequiredService<ISwaggerProvider>();
             var swaggerDocument = requiredService.GetSwagger(documentName, host);


### PR DESCRIPTION
Updates the generated swagger json to show host url from which the function was called.

Example:
`"host": "localhost",`