### PR TITLE
Make basepath and route prefix before operation optional

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/FunctionApiDescriptionProvider.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/FunctionApiDescriptionProvider.cs
@@ -58,11 +58,11 @@ namespace AzureFunctions.Extensions.Swashbuckle
                 string route;
                 if (_option.PrepandOperationWithRoutePrefix)
                 {
-                    route = !string.IsNullOrWhiteSpace(triggerAttribute.Route) ? triggerAttribute.Route : functionAttr.Name;
+                    route = $"{prefix}{(!string.IsNullOrWhiteSpace(triggerAttribute.Route) ? triggerAttribute.Route : functionAttr.Name)}";
                 }
                 else
                 {
-                    route = $"{prefix}{(!string.IsNullOrWhiteSpace(triggerAttribute.Route) ? triggerAttribute.Route : functionAttr.Name)}";
+                    route = !string.IsNullOrWhiteSpace(triggerAttribute.Route) ? triggerAttribute.Route : functionAttr.Name;
                 }
 
                 var routes = new List<(string Route, string RemoveParamName)>();

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Option.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Option.cs
@@ -7,7 +7,11 @@
         public string XmlPath { get; set; }
         public bool AddCodeParamater { get; set; } = true;
 
-        public OptionDocument[] Documents { get; set; } = {};
+        public OptionDocument[] Documents { get; set; } = { };
+
+        public bool PrepandOperationWithRoutePrefix { get; set; } = true;
+
+        public bool FillSwaggerBasePathWithRoutePrefix { get; set; } = false;
     }
 
     public class OptionDocument

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
@@ -137,7 +137,12 @@ namespace AzureFunctions.Extensions.Swashbuckle
         public Stream GetSwaggerDocument(string documentName = "v1")
         {
             var requiredService = _serviceProvider.GetRequiredService<ISwaggerProvider>();
-            var swaggerDocument = requiredService.GetSwagger(documentName);
+            string basePath = null;
+            if (_option.FillSwaggerBasePathWithRoutePrefix)
+            {
+                basePath = RoutePrefix;
+            }
+            var swaggerDocument = requiredService.GetSwagger(documentName, basePath: basePath);
             var mem = new MemoryStream();
             var streamWriter = new StreamWriter(mem);
             var mvcOptionsAccessor =

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashbuckleConfig.cs
@@ -69,8 +69,8 @@ namespace AzureFunctions.Extensions.Swashbuckle
 
 
         public SwashbuckleConfig(
-            IApiDescriptionGroupCollectionProvider apiDescriptionGroupCollectionProvider, 
-            IOptions<Option> functionsOptions, 
+            IApiDescriptionGroupCollectionProvider apiDescriptionGroupCollectionProvider,
+            IOptions<Option> functionsOptions,
             SwashBuckleStartupConfig startupConfig,
             IOptions<HttpOptions> httpOptions)
         {
@@ -119,16 +119,16 @@ namespace AzureFunctions.Extensions.Swashbuckle
                         AddSwaggerDocument(options, optionDocument);
                     }
                 }
-                
+
                 options.DescribeAllEnumsAsStrings();
 
-                if(!string.IsNullOrWhiteSpace(_xmlPath))
+                if (!string.IsNullOrWhiteSpace(_xmlPath))
                 {
                     options.IncludeXmlComments(_xmlPath);
                 }
                 options.OperationFilter<FunctionsOperationFilter>();
                 options.OperationFilter<QueryStringParameterAttributeFilter>();
-            });            
+            });
 
             _serviceProvider = services.BuildServiceProvider(true);
 
@@ -137,11 +137,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
         public Stream GetSwaggerDocument(string documentName = "v1")
         {
             var requiredService = _serviceProvider.GetRequiredService<ISwaggerProvider>();
-            string basePath = null;
-            if (_option.FillSwaggerBasePathWithRoutePrefix)
-            {
-                basePath = RoutePrefix;
-            }
+            string basePath = _option.FillSwaggerBasePathWithRoutePrefix ? $"/{RoutePrefix}" : null;
             var swaggerDocument = requiredService.GetSwagger(documentName, basePath: basePath);
             var mem = new MemoryStream();
             var streamWriter = new StreamWriter(mem);

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Users\yukaa\source\repos\Swashbuckle.WebJobs.Extensions\TestFunction\TestFunction.xml</DocumentationFile>
+    <DocumentationFile>TestFunction.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.24" />

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
@@ -24,6 +24,14 @@
             <param name="id">テストId</param>
             <returns>指定されたテスト</returns>
         </member>
+        <member name="M:TestFunction.TestController.GetCat(Microsoft.AspNetCore.Http.HttpRequest,System.Int32,System.Nullable{System.Int32})">
+            <summary>
+            テストの取得
+            </summary>
+            <param name="request"></param>
+            <param name="id">テストId</param>
+            <returns>指定されたテスト</returns>
+        </member>
         <member name="M:TestFunction.TestController.Add(TestFunction.TestController.TestModel)">
             <summary>
             テストの追加


### PR DESCRIPTION
Add extra options to make the basepath in a swagger document optional.
Also add extra option to not to prepand the operations with the route prefix. 

These options are needed for if you want to expose your function app into api management.

Use them as follow:

```json
"Swashbuckle": {
  "PrepandOperationWithRoutePrefix": false,
  "FillSwaggerBasePathWithRoutePrefix": true
}
```