### PR TITLE
fix array support for query string parameter

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/TypeExtensions.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/TypeExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AzureFunctions.Extensions.Swashbuckle
+{
+    public static class TypeExtensions
+    {
+
+        public static bool IsEnumerable(this Type type, out Type itemType)
+        {
+            if (type.IsConstructedFrom(typeof(IEnumerable<>), out Type constructedType))
+            {
+                itemType = constructedType.GenericTypeArguments[0];
+                return true;
+            }
+
+            if (typeof(IEnumerable).IsAssignableFrom(type))
+            {
+                itemType = typeof(object);
+                return true;
+            }
+
+            itemType = null;
+            return false;
+        }
+
+        private static bool IsConstructedFrom(this Type type, Type genericType, out Type constructedType)
+        {
+            constructedType = new[] { type }
+                .Union(type.GetInterfaces())
+                .FirstOrDefault(i => i.IsConstructedGenericType && i.GetGenericTypeDefinition() == genericType);
+
+            return (constructedType != null);
+        }
+
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestController.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -95,6 +96,32 @@ namespace TestFunction
             }
 
             return new OkResult();
+        }
+        
+        /// <summary>
+        /// Test array query parameters.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        [ProducesResponseType(typeof(TestModel[]), (int)HttpStatusCode.OK)]
+        [FunctionName("TestGetsArrayQueryParam")]
+        [QueryStringParameter("intList", "List of int", DataType = typeof(IEnumerable<int>), Required = false)]
+        [QueryStringParameter("stringList", "List of string", DataType = typeof(List<string>), Required = false)]
+        [QueryStringParameter("dateTimeList", "List of DateTime", DataType = typeof(DateTime[]), Required = false)]
+        [QueryStringParameter("guidList", "List of GUID", DataType = typeof(IList<Guid>), Required = false)]
+        [QueryStringParameter("defaultTypeParameter", "Default parameter", Required = false)]
+        [QueryStringParameter("intParameter", "Int parameter", DataType = typeof(int), Required = false)]
+        [QueryStringParameter("stringParameter", "String parameter", DataType = typeof(string), Required = false)]
+        [QueryStringParameter("dateTimeParameter", "DateTime parameter", DataType = typeof(DateTime), Required = false)]
+        [QueryStringParameter("guidParameter", "Guid parameter", DataType = typeof(Guid), Required = false)]
+        public async Task<IActionResult> GetsArrayQueryParam([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "testarray")] HttpRequest request)
+        {
+            var intList = request.Query["intList"].ToArray();
+            var stringList = request.Query["stringList"].ToArray();
+            var dateTimeList = request.Query["dateTimeList"].ToArray();
+            var defaultTypeParameter = request.Query["defaultTypeParameter"];
+            var intParameter = request.Query["intParameter"];
+            var stringParameter = request.Query["stringParameter"];
+            return new OkObjectResult(new[] { new TestModel(), new TestModel(), });
         }
 
         /// <summary>

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
@@ -46,6 +46,12 @@
             <param name="testModel">テストモデル</param>
             <returns>追加結果</returns>
         </member>
+        <member name="M:TestFunction.TestController.GetsArrayQueryParam(Microsoft.AspNetCore.Http.HttpRequest)">
+            <summary>
+            Test array query parameters.
+            </summary>
+            <param name="request">The request.</param>
+        </member>
         <member name="T:TestFunction.TestController.TestModel">
             <summary>
             テストモデル


### PR DESCRIPTION
- fix support for arrays in QueryStringParameter
- set also `format` property for more details about a query parameter